### PR TITLE
Switch to Azure AD auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Or install it yourself as:
 AzureMediaService.configure do |config|
  cofig.id = 'xxxxxxxx'
  config.secret = 'xxxxxxxxxxxxxxxxxx'
+ config.token_uri = 'https://login.microsoft.com/{tenant_id}/oauth2/token'
+ config.media_uri = 'https://{service}.restv2.{region}.media.azure.net/api/'
+ config.api_version = '2.xx' # Defaults to 2.9
 end
 
 # upload file

--- a/lib/azure_media_service.rb
+++ b/lib/azure_media_service.rb
@@ -21,33 +21,24 @@ module AzureMediaService
   @@tasks = {}
 
   class << self
+    attr_accessor :id
+    attr_accessor :token_uri
+    attr_accessor :media_uri
+    attr_accessor :api_version
+    attr_accessor :secret
 
     def configure
       yield self
     end
 
     def request
-      @@request ||= Request.new(client_id:@@id, client_secret:@@secret)
+      @request ||= Request.new(
+        client_id: @id, client_secret: @secret, tokenURI: @token_uri, mediaURI: @media_uri, api_version: @api_version
+      )
     end
 
     def service
-      @@service ||= Service.new
-    end
-
-    def id=(v)
-      @@id = v
-    end
-
-    def id
-      @@id
-    end
-
-    def secret=(v)
-      @@secret = v
-    end
-
-    def secret
-      @@secret
+      @service ||= Service.new
     end
 
     def add_encode_task(name, task)

--- a/lib/azure_media_service/config.rb
+++ b/lib/azure_media_service/config.rb
@@ -3,8 +3,6 @@ module AzureMediaService
     UPLOAD_LIMIT_SIZE = 4194304 # 4MB
     READ_BUFFER_SIZE       = 4000000
 
-    MEDIA_URI = "https://media.windows.net/api/"
-    TOKEN_URI = "https://wamsprodglobal001acs.accesscontrol.windows.net/v2/OAuth2-13"
-
+    API_VERSION = "2.9"
   end
 end

--- a/lib/azure_media_service/request.rb
+++ b/lib/azure_media_service/request.rb
@@ -123,17 +123,17 @@ module AzureMediaService
 
       @config = config || {}
       # @config[:mediaURI] = "https://media.windows.net/API/"
-      @config[:mediaURI] = Config::MEDIA_URI
-      @config[:tokenURI] = Config::TOKEN_URI
-      @config[:client_id] ||= ''
-      @config[:client_secret] ||= ''
+      @config[:mediaURI] || raise(MediaServiceError.new('Media URI missing, please specify in config'))
+      @config[:tokenURI] || raise(MediaServiceError.new('Token URI missing, please specify in config'))
+      @config[:client_id] || raise(MediaServiceError.new('Client ID missing, please specify in config'))
+      @config[:client_secret] || raise(MediaServiceError.new('Client secret missing, please specify in config'))
 
       @default_headers = {
         "Content-Type"          => "application/json;odata=verbose",
         "Accept"                => "application/json;odata=verbose",
         "DataServiceVersion"    => "3.0",
         "MaxDataServiceVersion" => "3.0",
-        "x-ms-version"          => "2.9"
+        "x-ms-version"          => @config[:api_version] || Config::API_VERSION
       }
     end
 
@@ -156,7 +156,7 @@ module AzureMediaService
           client_id: @config[:client_id], 
           client_secret: @config[:client_secret],
           grant_type: 'client_credentials',
-          scope: 'urn:WindowsAzureMediaServices'
+          resource: 'https://rest.media.azure.net'
         }
       end
 

--- a/spec/azure_media_service_ruby_spec.rb
+++ b/spec/azure_media_service_ruby_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe hoge do
-
-end

--- a/spec/azure_media_service_spec.rb
+++ b/spec/azure_media_service_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe AzureMediaService do
+  context '#configure should allow to set' do
+    it 'id' do
+      AzureMediaService.configure do |config|
+        config.id = 'client_id'
+      end
+
+      expect(AzureMediaService.id).to eq('client_id')
+    end
+
+    it 'secret' do
+      AzureMediaService.configure do |config|
+        config.secret = 'client_secret'
+      end
+
+      expect(AzureMediaService.secret).to eq('client_secret')
+    end
+
+    it 'token_uri' do
+      AzureMediaService.configure do |config|
+        config.token_uri = 'https://login.microsoft.com/tenant-id-goes-here/oauth2/token'
+      end
+
+      expect(AzureMediaService.token_uri).to eq('https://login.microsoft.com/tenant-id-goes-here/oauth2/token')
+    end
+
+    it 'media_uri' do
+      AzureMediaService.configure do |config|
+        config.media_uri = 'https://media-service-name.restv2.westeurope.media.azure.net/api/'
+      end
+
+      expect(AzureMediaService.media_uri).to eq('https://media-service-name.restv2.westeurope.media.azure.net/api/')
+    end
+
+    it 'api_version' do
+      AzureMediaService.configure do |config|
+        config.api_version = '2.17'
+      end
+
+      expect(AzureMediaService.api_version).to eq('2.17')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
 require 'rubygems'
 require 'bundler/setup'
-require 'azure_media_service_ruby'
-
+require 'azure_media_service'


### PR DESCRIPTION
Switch from ACS to AAD.

ACS will be deprecated starting 2018.06

 Also added config option api_version to specify different rest api version, added few specs